### PR TITLE
Working `node` Erlang module

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,10 +11,11 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-# 4 space indentation
+# 2 space indentation
 [*.{erl,src,hrl}]
 indent_style = space
-indent_size = 4
+indent_size = 2
+max_line_length = 100
 
 [**.{ex,exs}]
 indent_style = space

--- a/src/node.erl
+++ b/src/node.erl
@@ -1,14 +1,33 @@
 %% A node is one piece of a graph and can have many other nodes.
 -module(node).
--export([init/1, init/2]).
-% -compile(export_all).
+-export([new/1, new/2, append_children/2]).
 
 -record(node, {
-    value=nil,
-    children=[]
+    value = nil,
+    children = []
 }).
 
-init(Value) ->
-    init(Value, []).
-init(Value, Children) ->
+new(Value) ->
+    new(Value, []).
+new(Value, Children) when is_list(Children) ->
     #node{value = Value, children = Children}.
+
+append_children(Node, Child) when is_record(Child, node) ->
+    append_children(Node, [Child]);
+append_children(Node, [Child] = Children) ->
+    case lists:member(Child, Node#node.children) of
+        true ->
+            Node;
+        false ->
+            Node#node{children = lists:append(Children, Node#node.children)}
+    end;
+append_children(Node, Children) when is_list(Children) ->
+    Node#node{children = [child_appender(Node#node.children, C) || C <- Children ]}.
+
+child_appender(Children, Child) when is_list(Children), is_record(Child, node) ->
+    case lists:member(Child, Children) of
+        true ->
+            Children;
+        false ->
+            lists:append(Children, Child)
+    end.


### PR DESCRIPTION
Quick first pass of an Erlang module to hold arbitrary data and children.
Small .editorconfig update following style guide found [here](https://github.com/inaka/erlang_guidelines).